### PR TITLE
Add missing currencies

### DIFF
--- a/lib/data/countries/AQ.yaml
+++ b/lib/data/countries/AQ.yaml
@@ -4,9 +4,9 @@ AQ:
   alpha2: AQ
   alpha3: ATA
   country_code: '672'
-  currency: 
+  currency: 'USD'
   international_prefix: ''
-  ioc: 
+  ioc:
   gec: AY
   latitude: 90 00 S
   longitude: 0 00 E
@@ -28,9 +28,9 @@ AQ:
   languages: []
   nationality: ''
   postal_code: true
-  min_longitude: 
-  min_latitude: 
-  max_longitude: 
-  max_latitude: 
+  min_longitude:
+  min_latitude:
+  max_longitude:
+  max_latitude:
   latitude_dec: '-80.46617889404297'
   longitude_dec: '21.346302032470703'

--- a/lib/data/countries/AX.yaml
+++ b/lib/data/countries/AX.yaml
@@ -4,10 +4,10 @@ AX:
   alpha2: AX
   alpha3: ALA
   country_code: '358'
-  currency: 
+  currency: 'EUR'
   international_prefix: ''
-  ioc: 
-  gec: 
+  ioc:
+  gec:
   latitude: ''
   longitude: ''
   name: Åland Islands
@@ -23,14 +23,14 @@ AX:
   region: Europe
   subregion: Northern Europe
   world_region: EMEA
-  un_locode: 
+  un_locode:
   languages:
   - sv
   nationality: Swedish
   postal_code: true
-  min_longitude: 
-  min_latitude: 
-  max_longitude: 
-  max_latitude: 
+  min_longitude:
+  min_latitude:
+  max_longitude:
+  max_latitude:
   latitude_dec: '60.2023811340332'
   longitude_dec: '19.96520233154297'

--- a/lib/data/countries/CD.yaml
+++ b/lib/data/countries/CD.yaml
@@ -4,7 +4,7 @@ CD:
   alpha2: CD
   alpha3: COD
   country_code: '243'
-  currency:
+  currency: 'CDF'
   international_prefix: '00'
   ioc: COD
   gec: CG

--- a/lib/data/countries/CG.yaml
+++ b/lib/data/countries/CG.yaml
@@ -4,7 +4,7 @@ CG:
   alpha2: CG
   alpha3: COG
   country_code: '242'
-  currency: 
+  currency: 'XAF'
   international_prefix: '00'
   ioc: CGO
   gec: CF

--- a/lib/data/countries/GQ.yaml
+++ b/lib/data/countries/GQ.yaml
@@ -4,7 +4,7 @@ GQ:
   alpha2: GQ
   alpha3: GNQ
   country_code: '240'
-  currency: 
+  currency: 'XAF'
   international_prefix: '00'
   ioc: GEQ
   gec: EK

--- a/lib/data/countries/GS.yaml
+++ b/lib/data/countries/GS.yaml
@@ -4,9 +4,9 @@ GS:
   alpha2: GS
   alpha3: SGS
   country_code: '500'
-  currency: 
+  currency: 'GBP'
   international_prefix: ''
-  ioc: 
+  ioc:
   gec: SX
   latitude: 54 30 S
   longitude: 37 00 W

--- a/lib/data/countries/MG.yaml
+++ b/lib/data/countries/MG.yaml
@@ -4,7 +4,7 @@ MG:
   alpha2: MG
   alpha3: MDG
   country_code: '261'
-  currency: 
+  currency: 'MGA'
   international_prefix: '00'
   ioc: MAD
   gec: MA

--- a/lib/data/countries/MO.yaml
+++ b/lib/data/countries/MO.yaml
@@ -4,9 +4,9 @@ MO:
   alpha2: MO
   alpha3: MAC
   country_code: '853'
-  currency: 
+  currency: 'MOP'
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: MC
   latitude: 22 10 N
   longitude: 113 33 E

--- a/lib/data/countries/NU.yaml
+++ b/lib/data/countries/NU.yaml
@@ -4,9 +4,9 @@ NU:
   alpha2: NU
   alpha3: NIU
   country_code: '683'
-  currency: 
+  currency: 'NZD'
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: NE
   latitude: 19 02 S
   longitude: 169 52 W

--- a/lib/data/countries/PS.yaml
+++ b/lib/data/countries/PS.yaml
@@ -4,7 +4,7 @@ PS:
   alpha2: PS
   alpha3: PSE
   country_code: '970'
-  currency: 
+  currency: 'ILS'
   international_prefix: '00'
   ioc: PLE
   gec: WE
@@ -29,16 +29,16 @@ PS:
   region: Asia
   subregion: Western Asia
   world_region: EMEA
-  un_locode: 
+  un_locode:
   languages:
   - ar
   - he
   - en
   nationality: Palestinian
   postal_code: true
-  min_longitude: 
-  min_latitude: 
-  max_longitude: 
-  max_latitude: 
+  min_longitude:
+  min_latitude:
+  max_longitude:
+  max_latitude:
   latitude_dec: '31.946392059326172'
   longitude_dec: '35.259735107421875'

--- a/lib/data/countries/TM.yaml
+++ b/lib/data/countries/TM.yaml
@@ -4,7 +4,7 @@ TM:
   alpha2: TM
   alpha3: TKM
   country_code: '993'
-  currency: 
+  currency: TMT
   international_prefix: '810'
   ioc: TKM
   gec: TX

--- a/lib/data/countries/VU.yaml
+++ b/lib/data/countries/VU.yaml
@@ -4,7 +4,7 @@ VU:
   alpha2: VU
   alpha3: VUT
   country_code: '678'
-  currency: 
+  currency: 'VUV'
   international_prefix: '00'
   ioc: VAN
   gec: NH


### PR DESCRIPTION
Added missing Currencies based on newer data from .. the countries gem itself!!!

Anyway, this isn't the complete end of things are we still have

````ruby
Country.all.keep_if { |c| Country[c.last].currency.blank? }.map(&:last)
=> ["MO", "SS", "TM", "VU"]
```

why? Because `countries` depends on `currencies` and even the latest version doesn't have [`MOP`](https://github.com/hexorx/currencies/blob/master/lib/data/iso4217.yaml) (for Macau) - hilarious!

anyway, it's an improvement 

````ruby
Country.all.keep_if { |c| Country[c.last].currency.blank? }.map(&:last)
=> ["AQ", "AX", "CD", "CG", "GQ", "GS", "MG", "MO", "NU", "PS", "SS", "TM", "VU"]
````

and [this guy](https://homestay.airbrake.io/projects/93973/groups/1650652760874506668/notices/1652081886196581080) can go ahead 